### PR TITLE
QCD fixes for non-inclusive categories

### DIFF
--- a/Draw/python/nodes.py
+++ b/Draw/python/nodes.py
@@ -91,14 +91,16 @@ def GetVVJNode(ana, add_name ='', samples=[], plot='', wt='', sel='', cat='', vv
   return ana.SummedFactory('VVJ'+add_name, samples, plot, full_selection)
 
 
-def GetSubtractNode(ana, add_name, plot, plot_unmodified, wt, sel, cat, cat_data, categories, method, qcd_factor, OSSS, samples_dict, gen_sels_dict, includeW=False, w_shift=None):
+def GetSubtractNode(ana, add_name, plot, plot_unmodified, wt, sel, cat_name, categories, categories_unmodified, method, qcd_factor, OSSS, samples_dict, gen_sels_dict, includeW=False, w_shift=None):
+    cat = categories[cat_name]
+    cat_data = categories_unmodified[cat_name]
     subtract_node = Analysis.SummedNode('total_bkg'+add_name)
     if includeW:
         if w_shift is not None:
             w_wt = '%s*%f' %(wt,w_shift)
         else:
             w_wt = wt
-        w_node = GetWNode(ana, 'W', samples_dict, gen_sels_dict, plot, plot_unmodified, w_wt, sel, cat, cat_data, categories, method, qcd_factor, OSSS)
+        w_node = GetWNode(ana, 'W', samples_dict, gen_sels_dict, plot, plot_unmodified, w_wt, sel, cat_name, categories, categories_unmodified,  method, qcd_factor, OSSS)
         subtract_node.AddNode(w_node)
     ttt_node = GetTTTNode(ana, "", samples_dict['top_samples'], plot, wt, sel, cat, gen_sels_dict['top_sels'], OSSS)
     ttj_node = GetTTJNode(ana, "", samples_dict['top_samples'], plot, wt, sel, cat, gen_sels_dict['top_sels'], OSSS)
@@ -119,7 +121,9 @@ def GetSubtractNode(ana, add_name, plot, plot_unmodified, wt, sel, cat, cat_data
 
     return subtract_node
 
-def GetWNode(ana, name='W', samples_dict={}, gen_sels_dict={}, plot='',plot_unmodified='', wt='', sel='', cat='', cat_data='', categories={}, method=1, qcd_factor=1.0, get_os=True):
+def GetWNode(ana, name='W', samples_dict={}, gen_sels_dict={}, plot='',plot_unmodified='', wt='', sel='', cat_name='', categories={}, categories_unmodified={}, method=1, qcd_factor=1.0, get_os=True):
+    cat = categories['cat']
+    cat_data = categories_unmodified['cat']
     if get_os:
         OSSS = 'os'
     else:
@@ -144,8 +148,8 @@ def GetWNode(ana, name='W', samples_dict={}, gen_sels_dict={}, plot='',plot_unmo
         w_control_full_selection_ss_data = BuildCutString("weight", control_sel, cat_data, '!os')
         btag_extrap_num_node = None
         btag_extrap_den_node = None
-        subtract_node_os = GetSubtractNode(ana, '_os', plot, plot_unmodified, wt,control_sel, cat, cat_data, categories, method, qcd_factor, True, samples_dict, gen_sels_dict, False)
-        subtract_node_ss = GetSubtractNode(ana, '_ss', plot, plot_unmodified, wt,control_sel, cat, cat_data, categories, method, qcd_factor, False, samples_dict, gen_sels_dict, False)
+        subtract_node_os = GetSubtractNode(ana, '_os', plot, plot_unmodified, wt,control_sel, 'cat', categories, categories_unmodified, method, qcd_factor, True, samples_dict, gen_sels_dict, False)
+        subtract_node_ss = GetSubtractNode(ana, '_ss', plot, plot_unmodified, wt,control_sel, 'cat', categories, categories_unmodified, method, qcd_factor, False, samples_dict, gen_sels_dict, False)
 
         if shape_selection == full_selection:
             w_shape = None
@@ -208,17 +212,20 @@ def GenerateVV(ana, nodename, add_name ='', samples=[], plot='', wt='', sel='', 
       ana.nodes[nodename].AddNode(vvj_node)
 
 
-def GenerateW(ana, nodename, add_name='', samples_dict={}, gen_sels_dict={}, plot='', plot_unmodified='', wt='', sel='', cat='', cat_data='', categories={}, method=1, qcd_factor=1.0, get_os=True):
+def GenerateW(ana, nodename, add_name='', samples_dict={}, gen_sels_dict={}, plot='', plot_unmodified='', wt='', sel='', cat_name='', categories={}, categories_unmodified={}, method=1, qcd_factor=1.0, get_os=True):
   w_node_name = 'W'
-  ana.nodes[nodename].AddNode(GetWNode(ana, w_node_name+add_name, samples_dict, gen_sels_dict, plot, plot_unmodified, wt, sel, cat, cat_data, categories, method, qcd_factor, get_os))
+  ana.nodes[nodename].AddNode(GetWNode(ana, w_node_name+add_name, samples_dict, gen_sels_dict, plot, plot_unmodified, wt, sel, cat_name, categories, categories_unmodified,  method, qcd_factor, get_os))
 
 
-def GenerateQCD(ana, nodename, add_name='', samples_dict={}, gen_sels_dict={}, systematic='', plot='', plot_unmodified='', wt='', sel='', cat='', cat_data='', categories={}, method=1, qcd_factor=1.0, get_os=True,w_shift=None):
+def GenerateQCD(ana, nodename, add_name='', samples_dict={}, gen_sels_dict={}, systematic='', plot='', plot_unmodified='', wt='', sel='', cat_name='', categories={}, categories_unmodified={}, method=1, qcd_factor=1.0, get_os=True,w_shift=None):
     shape_node = None
     if get_os:
         OSSS = "os"
     else:
         OSSS = "!os"
+
+    cat = categories['cat']    
+    cat_data = categories_unmodified['cat']    
 
     if method in [1,2]:
         sub_shift='*1.0'
@@ -231,7 +238,7 @@ def GenerateQCD(ana, nodename, add_name='', samples_dict={}, gen_sels_dict={}, s
         # HERE
         data_weight = '(weight)'
         full_selection = BuildCutString(data_weight, sel, cat_data, '!os')
-        subtract_node = GetSubtractNode(ana , '', plot, plot_unmodified, wt+sub_shift, sel, cat, cat_data, categories, method, qcd_factor, False, samples_dict, gen_sels_dict, includeW=True, w_shift=w_shift)
+        subtract_node = GetSubtractNode(ana , '', plot, plot_unmodified, wt+sub_shift, sel, 'cat', categories, categories_unmodified, method, qcd_factor, False, samples_dict, gen_sels_dict, includeW=True, w_shift=w_shift)
 
         if get_os:
             qcd_ratio = qcd_factor
@@ -250,24 +257,24 @@ def GenerateQCD(ana, nodename, add_name='', samples_dict={}, gen_sels_dict={}, s
         data_weight = '(weight)'
 
         # TODO: Options.cat
-        qcd_sdb_cat = categories['tt_qcd_norm']
-        qcd_sdb_cat_data = categories['tt_qcd_norm']
+        categories['qcd_sdb_cat'] = categories[cat_name]+'&&'+categories['tt_qcd_norm']
+        categories_unmodified['qcd_sdb_cat'] = categories_unmodified[cat_name]+'&&'+categories_unmodified['tt_qcd_norm'] 
 
-        subtract_node = GetSubtractNode(ana, '', plot, plot_unmodified, wt, sel, cat, cat_data, categories, method, qcd_factor, False, samples_dict, gen_sels_dict, includeW=True)
+        subtract_node = GetSubtractNode(ana, '', plot, plot_unmodified, wt, sel, 'cat', categories, categories_unmodified, method, qcd_factor, False, samples_dict, gen_sels_dict, includeW=True)
         num_selection = BuildCutString(data_weight, sel, cat_data, '!os')
         num_node = Analysis.SubtractNode('ratio_num',
                        ana.SummedFactory('data', samples_dict['data_samples'], plot_unmodified, num_selection),
                        subtract_node)
 
-        subtract_node = GetSubtractNode(ana, '', plot, plot_unmodified, wt, sel, qcd_sdb_cat, qcd_sdb_cat_data, categories, method, qcd_factor, False, samples_dict, gen_sels_dict, includeW=True)
-        den_selection = BuildCutString(data_weight, sel, qcd_sdb_cat_data, '!os')
+        subtract_node = GetSubtractNode(ana, '', plot, plot_unmodified, wt, sel, 'qcd_sdb_cat', categories, categories_unmodified, method, qcd_factor, False, samples_dict, gen_sels_dict, includeW=True)
+        den_selection = BuildCutString(data_weight, sel, categories_unmodified['qcd_sdb_cat'], '!os')
         den_node = Analysis.SubtractNode('ratio_den',
                        ana.SummedFactory('data', samples_dict['data_samples'], plot_unmodified, den_selection),
                        subtract_node)
 
         shape_node = None
-        full_selection = BuildCutString(data_weight, sel, qcd_sdb_cat_data, OSSS)
-        subtract_node = GetSubtractNode(ana, '', plot, plot_unmodified, wt, sel, qcd_sdb_cat, qcd_sdb_cat_data, categories, method, qcd_factor, get_os, samples_dict, gen_sels_dict, includeW=True)
+        full_selection = BuildCutString(data_weight, sel, categories_unmodified['qcd_sdb_cat'], OSSS)
+        subtract_node = GetSubtractNode(ana, '', plot, plot_unmodified, wt, sel, 'qcd_sdb_cat', categories, categories_unmodified, method, qcd_factor, get_os, samples_dict, gen_sels_dict, includeW=True)
 
         ana.nodes[nodename].AddNode(Analysis.HttQCDNode('QCD'+add_name,
             ana.SummedFactory('data', samples_dict['data_samples'], plot_unmodified, full_selection),

--- a/Draw/scripts/HiggsTauTauPlot.py
+++ b/Draw/scripts/HiggsTauTauPlot.py
@@ -253,16 +253,15 @@ def RunPlotting(ana, nodename, samples_dict, gen_sels_dict, systematic='', cat_n
     samples_dict: dictionary containing the samples
     gen_sels_dict: dictionary containing the gen selections
     systematic: systematic variation
-    cat: category to be used for the selection
-    cat_data: category to be used for the data selection
+    cat_name: the name of the category to be used for the data selection
     categories: dictionary containing the categories
+    categories_unmodified: dictionary containing the categories - unmodified by any systematic variations - to be applied for data only
     sel: additional selection
     add_name: additional name to be added to the process (e.g. ZTT + xxx)
     wt: weight to be applied
     do_data: boolean to decide if data should be added
     qcd_factor: factor to be applied to QCD
     '''
-    #TODO: modify the above descriptions!
 
     cat = categories['cat']
     cat_data = categories_unmodified['cat']

--- a/Draw/scripts/HiggsTauTauPlot.py
+++ b/Draw/scripts/HiggsTauTauPlot.py
@@ -245,7 +245,7 @@ gen_sels_dict['vv_sels'] = vv_sels
 
 # RunPlotting handles how each process is added to the analysis
 
-def RunPlotting(ana, nodename, samples_dict, gen_sels_dict, systematic='', cat='', cat_data='', categories={}, sel='', add_name='', wt='wt', do_data=True, qcd_factor=1.0, method=1):
+def RunPlotting(ana, nodename, samples_dict, gen_sels_dict, systematic='', cat_name='', categories={}, categories_unmodified={}, sel='', add_name='', wt='wt', do_data=True, qcd_factor=1.0, method=1):
     '''
     RunPlotting handles how each process is added to the analysis
     ana: Analysis object
@@ -262,6 +262,11 @@ def RunPlotting(ana, nodename, samples_dict, gen_sels_dict, systematic='', cat='
     do_data: boolean to decide if data should be added
     qcd_factor: factor to be applied to QCD
     '''
+    #TODO: modify the above descriptions!
+
+    cat = categories['cat']
+    cat_data = categories_unmodified['cat']
+
 
     doZL = True
     doZJ = True
@@ -283,8 +288,8 @@ def RunPlotting(ana, nodename, samples_dict, gen_sels_dict, systematic='', cat='
     GenerateZLL(ana, nodename, add_name, samples_dict['ztt_samples'], plot, wt, sel, cat, gen_sels_dict['z_sels'], not args.do_ss, doZL, doZJ)
     GenerateTop(ana, nodename, add_name, samples_dict['top_samples'], plot, wt, sel, cat, gen_sels_dict['top_sels'], not args.do_ss, doTTT, doTTJ)
     GenerateVV(ana, nodename, add_name, samples_dict['vv_samples'], plot, wt, sel, cat, gen_sels_dict['vv_sels'], not args.do_ss, doVVT, doVVJ)
-    GenerateW(ana, nodename, add_name, samples_dict, gen_sels_dict, plot, plot_unmodified, wt, sel, cat, cat_data, categories, method=method, qcd_factor=qcd_factor, get_os=not args.do_ss)
-    GenerateQCD(ana, nodename, add_name, samples_dict, gen_sels_dict, systematic, plot, plot_unmodified, wt, sel, cat, cat_data, categories=categories, method=method, qcd_factor=qcd_factor, get_os=not args.do_ss)
+    GenerateW(ana, nodename, add_name, samples_dict, gen_sels_dict, plot, plot_unmodified, wt, sel, cat_name, categories, categories_unmodified=categories_unmodified, method=method, qcd_factor=qcd_factor, get_os=not args.do_ss)
+    GenerateQCD(ana, nodename, add_name, samples_dict, gen_sels_dict, systematic, plot, plot_unmodified, wt, sel, cat_name, categories=categories, categories_unmodified=categories_unmodified, method=method, qcd_factor=qcd_factor, get_os=not args.do_ss)
 # ------------------------------------------------------------------------------------------------------------------------
 
 # ------------------------------------------------------------------------------------------------------------------------
@@ -365,6 +370,7 @@ while len(systematics) > 0:
 
         sel = args.sel
         plot = args.var
+        # use plot_unmodified and categories_unmodified in cases where the data and MC get different selections due to a systematic variation
         plot_unmodified = plot
         categories_unmodified = copy.deepcopy(categories)
         systematic_folder_name = systematics[systematic][0]
@@ -387,7 +393,7 @@ while len(systematics) > 0:
             do_data = True
         else:
             do_data = False
-        RunPlotting(analysis, nodename, samples_dict, gen_sels_dict, systematic, categories['cat'], categories_unmodified['cat'], categories_unmodified, sel, systematic_suffix, weight, do_data, qcd_factor, method)
+        RunPlotting(analysis, nodename, samples_dict, gen_sels_dict, systematic, args.category, categories, categories_unmodified, sel, systematic_suffix, weight, do_data, qcd_factor, method)
 
         del systematics[systematic]
 


### PR DESCRIPTION
- Changes to allow QCD method to work properly in cases where cat != inclusive
- A few changes were needed to how cat / cat_data are defined to make this work, which may affect other parts of the code